### PR TITLE
EventEmitter + setPreferentialGauge

### DIFF
--- a/abis/EventEmitter.json
+++ b/abis/EventEmitter.json
@@ -1,0 +1,198 @@
+[
+	{
+		"inputs": [],
+		"stateMutability": "nonpayable",
+		"type": "constructor"
+	},
+	{
+		"anonymous": false,
+		"inputs": [
+			{
+				"indexed": true,
+				"internalType": "address",
+				"name": "addr",
+				"type": "address"
+			},
+			{
+				"indexed": true,
+				"internalType": "bytes32",
+				"name": "identifier",
+				"type": "bytes32"
+			}
+		],
+		"name": "AuthorizationGranted",
+		"type": "event"
+	},
+	{
+		"anonymous": false,
+		"inputs": [
+			{
+				"indexed": true,
+				"internalType": "address",
+				"name": "addr",
+				"type": "address"
+			},
+			{
+				"indexed": true,
+				"internalType": "bytes32",
+				"name": "identifier",
+				"type": "bytes32"
+			}
+		],
+		"name": "AuthorizationRevoked",
+		"type": "event"
+	},
+	{
+		"anonymous": false,
+		"inputs": [
+			{
+				"indexed": true,
+				"internalType": "address",
+				"name": "sender",
+				"type": "address"
+			},
+			{
+				"indexed": true,
+				"internalType": "bytes32",
+				"name": "identifier",
+				"type": "bytes32"
+			},
+			{
+				"indexed": false,
+				"internalType": "bytes",
+				"name": "message",
+				"type": "bytes"
+			},
+			{
+				"indexed": false,
+				"internalType": "uint256",
+				"name": "value",
+				"type": "uint256"
+			}
+		],
+		"name": "LogArgument",
+		"type": "event"
+	},
+	{
+		"anonymous": false,
+		"inputs": [
+			{
+				"indexed": true,
+				"internalType": "address",
+				"name": "newOwner",
+				"type": "address"
+			}
+		],
+		"name": "OwnershipTransferred",
+		"type": "event"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "bytes32",
+				"name": "identifier",
+				"type": "bytes32"
+			},
+			{
+				"internalType": "address",
+				"name": "addr",
+				"type": "address"
+			}
+		],
+		"name": "authorize",
+		"outputs": [],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "bytes32",
+				"name": "identifier",
+				"type": "bytes32"
+			},
+			{
+				"internalType": "bytes",
+				"name": "message",
+				"type": "bytes"
+			},
+			{
+				"internalType": "uint256",
+				"name": "value",
+				"type": "uint256"
+			}
+		],
+		"name": "emitEvent",
+		"outputs": [],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "",
+				"type": "address"
+			},
+			{
+				"internalType": "bytes32",
+				"name": "",
+				"type": "bytes32"
+			}
+		],
+		"name": "isAuthorized",
+		"outputs": [
+			{
+				"internalType": "bool",
+				"name": "",
+				"type": "bool"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [],
+		"name": "owner",
+		"outputs": [
+			{
+				"internalType": "address",
+				"name": "",
+				"type": "address"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "bytes32",
+				"name": "identifier",
+				"type": "bytes32"
+			},
+			{
+				"internalType": "address",
+				"name": "addr",
+				"type": "address"
+			}
+		],
+		"name": "removeAuthorization",
+		"outputs": [],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "newOwner",
+				"type": "address"
+			}
+		],
+		"name": "transferOwnership",
+		"outputs": [],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	}
+]

--- a/manifest.template.yaml
+++ b/manifest.template.yaml
@@ -23,7 +23,7 @@ dataSources:
       kind: ethereum/events
       apiVersion: 0.0.5
       language: wasm/assemblyscript
-      file: ./src/mappings/eventEmitter.ts
+      file: ./src/eventEmitter.ts
       entities:
         - Pool
       abis:

--- a/manifest.template.yaml
+++ b/manifest.template.yaml
@@ -11,6 +11,28 @@ repository: https://github.com/balancer-labs/gauges-subgraph/
 schema:
   file: ./schema.graphql
 dataSources:
+  {{#if EventEmitter}}
+  - kind: ethereum/contract
+    name: EventEmitter
+    network: {{network}}
+    source:
+      address: '{{EventEmitter.address}}'
+      abi: EventEmitter
+      startBlock: {{EventEmitter.startBlock}}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.5
+      language: wasm/assemblyscript
+      file: ./src/mappings/eventEmitter.ts
+      entities:
+        - Pool
+      abis:
+        - name: EventEmitter
+          file: ./abis/EventEmitter.json
+      eventHandlers:
+        - event: LogArgument(indexed address,indexed bytes32,bytes,uint256)
+          handler: handleLogArgument
+  {{/if}}
   {{#if gaugeFactory}}
   - kind: ethereum/contract
     name: GaugeFactory

--- a/networks.yaml
+++ b/networks.yaml
@@ -93,8 +93,8 @@ mainnet:
 polygon:
   network: matic
   graft:
-    block: 40687417
-    base: QmU5c6nMwLYogKTimpWbiqXd2YeY1ovbo4dLRSgd2UBB7m
+    block: 42247242
+    base: QmcSEjV1MgaKjHLFCuAXDeNZysXX7wK36YJWKT1R4RKnko
   EventEmitter:
     address: "0xcdcECFa416EE3022030E707dC3EA13a8997D74c8"
     startBlock: 38152461
@@ -109,8 +109,8 @@ polygon:
 arbitrum:
   network: arbitrum-one
   graft:
-    block: 72942741
-    base: QmQNtqzZbE4JsXBUzeMvUHkJYGv2YVKtKet7d4Zn4Wzs2r
+    block: 86871634
+    base: QmccYAZWRRXmAKGJPqW5CRKcuRB5B1Ckn5otomKsBEqNk5
   EventEmitter:
     address: "0x8f32D631093B5418d0546f77442c5fa66187E59D"
     startBlock: 53475240
@@ -125,8 +125,8 @@ arbitrum:
 optimism:
   network: optimism
   graft:
-    base: QmSyjna4aFT7rUVwKzsWBf8qZ4nicAnEAKn8V7Sis8KPWz
-    block: 83239534
+    base: QmdFVHmuKXvf44SCqFjCJbpfh4UWKQ6s3RVVsqDg597Vge
+    block: 96122413
   childChainGaugeFactory:
     address: "0x2E96068b3D5B5BAE3D7515da4A1D2E52d08A2647"
     transactionHash: "0x4afed3f4aaa2e32a3313db5fe5e42faf54b4d59f8003bed8316914510c4112f7"

--- a/networks.yaml
+++ b/networks.yaml
@@ -125,6 +125,9 @@ optimism:
     startBlock: 83239534
 gnosis:
   network: gnosis
+  EventEmitter:
+    address: "0xd8bf95b44772213905a8a74881862347acbabc48"
+    startBlock: 26892431
   childChainGaugeFactory:
     address: "0x809B79b53F18E9bc08A961ED4678B901aC93213a"
     transactionHash: "0x80b812c2b44d29e5e6c5275ece19ca506933f63002890a733ec38f925e6aee97"

--- a/networks.yaml
+++ b/networks.yaml
@@ -1,6 +1,9 @@
 goerli:
   network: goerli
   supportTraces: true
+  EventEmitter:
+    address: "0x4bcFCEDF1114030ff85a647dD436B7b3dEb45d9E"
+    startBlock: 8305794
   gaugeFactory:
     address: "0x224E808FBD9e491Be8988B8A0451FBF777C81B8A"
     transactionHash: "0x2d5d9089caf830b09e6ab586b56b140e6e0ab28d2d2070425bfb97ada9c95d08"
@@ -32,6 +35,9 @@ goerli:
 mainnet:
   network: mainnet
   supportTraces: true
+  EventEmitter:
+    address: "0x1ACfEEA57d2ac674d7E65964f155AB9348A6C290"
+    startBlock: 16419620
   gaugeFactory:
     address: "0x4E7bBd911cf1EFa442BC1b2e9Ea01ffE785412EC"
     transactionHash: "0x69b9fe9b5530d8640cb66546dffd7deeca2bdf40e005caf3049836fa031b640d"
@@ -89,6 +95,9 @@ polygon:
   graft:
     block: 40687417
     base: QmU5c6nMwLYogKTimpWbiqXd2YeY1ovbo4dLRSgd2UBB7m
+  EventEmitter:
+    address: "0xcdcECFa416EE3022030E707dC3EA13a8997D74c8"
+    startBlock: 38152461
   childChainGaugeFactory:
     address: "0x3b8cA519122CdD8efb272b0D3085453404B25bD0"
     transactionHash: "0x0dcff784ada6e0e4e21db3da70e09545d31c3e425cf028df7d1289f914a7f1d5"
@@ -102,6 +111,9 @@ arbitrum:
   graft:
     block: 72942741
     base: QmQNtqzZbE4JsXBUzeMvUHkJYGv2YVKtKet7d4Zn4Wzs2r
+  EventEmitter:
+    address: "0x8f32D631093B5418d0546f77442c5fa66187E59D"
+    startBlock: 53475240
   childChainGaugeFactory:
     address: "0xb08E16cFc07C684dAA2f93C70323BAdb2A6CBFd2"
     transactionHash: "0x4cc294e3e988adc1d0f0244451426583284f5270acb865f87ac55e18fe405874"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "deploy:mainnet": "yarn deploy balancer-labs/gauges",
     "deploy:goerli": "yarn deploy balancer-labs/gauges-goerli",
     "codegen": "yarn generate-manifests && graph codegen subgraph.yaml --output-dir src/types/ && graph codegen subgraph.arbitrum.yaml --output-dir src/types/",
-    "generate-manifests": "ts-node ./scripts/generate-manifests"
+    "generate-manifests": "ts-node ./scripts/generate-manifests",
+    "build": "graph build"
   },
   "repository": {
     "type": "git",

--- a/src/eventEmitter.ts
+++ b/src/eventEmitter.ts
@@ -14,7 +14,8 @@ export function handleLogArgument(event: LogArgument): void {
 
 function setPreferentialGauge(event: LogArgument): void {
   /**
-   * Sets a gauge as the preferential gauge
+   * Sets/Unsets a gauge as the preferential gauge
+   * It is expected that a new gauge will be set as preferential after unsetting the old one
    *
    * @param message - The gauge address (eg. 0x12345abce... - all lowercase)
    * @param value - 0 if swapEnabled is to be set false; any other value sets it to true

--- a/src/eventEmitter.ts
+++ b/src/eventEmitter.ts
@@ -1,0 +1,52 @@
+import { LogArgument } from './types/EventEmitter/EventEmitter';
+import { Pool, LiquidityGauge } from './types/schema';
+import { BigDecimal } from '@graphprotocol/graph-ts';
+
+export function handleLogArgument(event: LogArgument): void {
+  const identifier = event.params.identifier.toHexString();
+
+  // convention: identifier = keccak256(function_name)
+  // keccak256(setPreferentialGauge) = 0x88aea7780a038b8536bb116545f59b8a089101d5e526639d3c54885508ce50e2
+  if (identifier == '0x88aea7780a038b8536bb116545f59b8a089101d5e526639d3c54885508ce50e2') {
+    setPreferentialGauge(event);
+  }
+}
+
+function setPreferentialGauge(event: LogArgument): void {
+  /**
+   * Sets a gauge as the preferential gauge
+   *
+   * @param message - The gauge address (eg. 0x12345abce... - all lowercase)
+   * @param value - 0 if swapEnabled is to be set false; any other value sets it to true
+   */ //
+  const gaugeId = event.params.message.toHexString();
+  const gauge = LiquidityGauge.load(gaugeId);
+  if (!gauge) return;
+
+  if (event.params.value.toI32() == 0) {
+    gauge.isPreferentialGauge = false;
+    // Update Pool's preferentialGauge
+
+    let poolId = gauge.pool;
+    if (poolId === null) return;
+
+    let pool = Pool.load(poolId);
+    if (pool == null) return;
+
+    pool.preferentialGauge = "";
+    pool.save();
+  } else {
+    gauge.isPreferentialGauge = true;
+    // Update Pool's preferentialGauge
+
+    let poolId = gauge.pool;
+    if (poolId === null) return;
+
+    let pool = Pool.load(poolId);
+    if (pool == null) return;
+
+    pool.preferentialGauge = gaugeId;
+    pool.save();
+  }
+  gauge.save();
+}

--- a/src/eventEmitter.ts
+++ b/src/eventEmitter.ts
@@ -1,6 +1,5 @@
 import { LogArgument } from './types/EventEmitter/EventEmitter';
 import { Pool, LiquidityGauge } from './types/schema';
-import { BigDecimal } from '@graphprotocol/graph-ts';
 
 export function handleLogArgument(event: LogArgument): void {
   const identifier = event.params.identifier.toHexString();


### PR DESCRIPTION
There is no robust mechanism to set the preferential gauge based on native events in the system for L2 gauges. This PR makes the gauges subgraph aware of the curation contract (EventEmitter) that we've been experimenting with in the core subgraph, and introduces the ability to set the preferential gauge of a pool via a call to that contract.