### PR TITLE
Revert "hotfix: update graft params and event emitter on polygon"

### DIFF
--- a/networks.yaml
+++ b/networks.yaml
@@ -81,12 +81,12 @@ mainnet:
     startBlock: 16042168
 polygon:
   network: matic
-  graft:
-    block: 43727985
-    base: Qmf9qeFRZMLMGumWLUmiBKwY2F26SLGGmK81j1k25z5ogk
+  # graft:
+  #   block: 42610000
+  #   base: QmTMYUbqpYZEYAzBTbMLmNgb13UyzdvyuKbfWMKJFzPWWB
   EventEmitter:
-    address: "0xf54546fed816bc7d412a133a4580cff03da2f282"
-    startBlock: 43727985
+    address: "0xcdcECFa416EE3022030E707dC3EA13a8997D74c8"
+    startBlock: 38152461
   childChainGaugeFactory:
     address: "0x3b8cA519122CdD8efb272b0D3085453404B25bD0"
     startBlock: 27098624


### PR DESCRIPTION
Reverts balancer/gauges-subgraph#61
Preferential gauges have now been set in the original event emitter contract ([check](https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges-polygon-beta/graphql?query=%7B%0A++pools+%28%0A++++%23+block%3A%7Bnumber%3A43863955%7D%0A++++where%3A%7B%0A++++poolId%3A%220x924ec7ed38080e40396c46f6206a6d77d0b9f72d00020000000000000000072a%22%0A++%7D%29+%7B%0A++++id%0A++++poolId%0A++++gauges+%7B%0A++++++id%0A++++++isPreferentialGauge%0A++++%7D%0A++++preferentialGauge+%7B%0A++++++id%0A++++%7D%0A++%7D%0A%0A%7D))
