### PR TITLE
update gnosis graft block

### DIFF
--- a/networks.yaml
+++ b/networks.yaml
@@ -169,7 +169,7 @@ optimism:
 gnosis:
   network: gnosis
   graft:
-    block: 29344803
+    block: 29344802
     base: QmbF9ybzefDh29hdERkY9VxwMrvA15U5sgVcnPJxDpEwbC
   EventEmitter:
     address: "0xd8bf95b44772213905a8a74881862347acbabc48"


### PR DESCRIPTION
Fixing:

deployment failure::subgraph validation error: [the graft base is invalid: failed to graft onto `QmbF9ybzefDh29hdERkY9VxwMrvA15U5sgVcnPJxDpEwbC` at block 29344803 since it's not healthy. You can graft it starting at block 29344802 backwards]
