### PR TITLE
add liq gauge abi to manifest

### DIFF
--- a/manifest.template.yaml
+++ b/manifest.template.yaml
@@ -820,6 +820,8 @@ templates:
       abis:
         - name: GaugeInjector
           file: ./abis/ChildChainGaugeInjector.json
+        - name: ChildChainLiquidityGaugeV2
+          file: ./abis/ChildChainLiquidityGaugeV2.json
       eventHandlers:
         - event: EmissionsInjection(address,address,uint256)
           handler: handleEmissionsInjection


### PR DESCRIPTION
https://thegraph.com/hosted-service/subgraph/balancer-labs/balancer-gauges-arbitrum-beta?selected=logs

Subgraph failed with non-deterministic error: failed to process trigger: block #155900860 (0xae8e…6f25), transaction 49dc4cf3da821752277f8a54b8eec218d0a012c6ad4b5e1f73ede4a5c5bdeccd: Could not find ABI for contract "ChildChainLiquidityGaugeV2", try adding it to the 'abis' section of the subgraph manifest wasm backtrace: 0: 0x25fc - <unknown>!~lib/@graphprotocol/graph-ts/chain/ethereum/ethereum.SmartContract#tryCall 1: 0x40ca - <unknown>!src/utils/gauge/setRewardData 2: 0x4513 - <unknown>!src/gaugeInjector/handleEmissionsInjection , retry_delay_s: 3368, attempt: 5

