### PR TITLE
promote to prod

### DIFF
--- a/networks.yaml
+++ b/networks.yaml
@@ -31,6 +31,9 @@ goerli:
 mainnet:
   network: mainnet
   supportTraces: true
+  graft:
+    base: QmbfxmF1pMSQPRtk4y4GC6Y946fNy7bjraJEp6aYpojTDt
+    block: 17331264
   EventEmitter:
     address: "0x1ACfEEA57d2ac674d7E65964f155AB9348A6C290"
     startBlock: 16419620
@@ -111,9 +114,9 @@ sepolia:
     startBlock: 3421600
 polygon:
   network: matic
-  # graft:
-  #   block: 42610000
-  #   base: QmTMYUbqpYZEYAzBTbMLmNgb13UyzdvyuKbfWMKJFzPWWB
+  graft:
+    block: 43103222
+    base: QmXBbUTPQPMUM57xT5GnxMKuR4UAmZwk3Gk6GTYiR5q2qW
   EventEmitter:
     address: "0xcdcECFa416EE3022030E707dC3EA13a8997D74c8"
     startBlock: 38152461
@@ -131,9 +134,9 @@ polygon:
     startBlock: 36020863
 arbitrum:
   network: arbitrum-one
-  # graft:
-  #   block: 80501659
-  #   base: QmcKEX764wP6e62ywbZd28b1VFx5iq7jYzs8c3SM53PJce
+  graft:
+    block: 94050211
+    base: QmWRWxeDNcMTRsU35hF6aHKKXf9VsEDcaTzdcJnYS9gKLY
   EventEmitter:
     address: "0x8f32D631093B5418d0546f77442c5fa66187E59D"
     startBlock: 53475240
@@ -151,9 +154,9 @@ arbitrum:
     startBlock: 40916259
 optimism:
   network: optimism
-  # graft:
-  #   base: QmQVriEjvBtusHjLv88neMNPCwPzvHRsRhvFyQxbcZMepH
-  #   block: 99765962
+  graft:
+    base: Qme4tckejtJmmRDM6gVDre99wVUY6FeckSrtswkA2GDeTZ
+    block: 101185055
   EventEmitter:
     address: "0x082990116f256E078572a1b69772115d2cF6b0a2"
     startBlock: 99124541
@@ -171,9 +174,9 @@ optimism:
     startBlock: 41872979
 gnosis:
   network: gnosis
-  # graft:
-  #   block: 29344802
-  #   base: QmbF9ybzefDh29hdERkY9VxwMrvA15U5sgVcnPJxDpEwbC
+  graft:
+    block: 28110199
+    base: QmXpWX5esNz1JHHmmn4whNc6pHHZ8VPPmvVWnuxNLSmQYE
   EventEmitter:
     address: "0xd8bf95b44772213905a8a74881862347acbabc48"
     startBlock: 26892431

--- a/src/gaugeController.ts
+++ b/src/gaugeController.ts
@@ -79,7 +79,11 @@ export function handleNewGauge(event: NewGauge): void {
     pool.preferentialGauge = liquidityGauge.id;
     pool.save();
 
-    if (currentPreferentialGaugeId === null) return;
+    if (
+      currentPreferentialGaugeId === null ||
+      currentPreferentialGaugeId == liquidityGauge.id
+    )
+      return;
     let currentPreferentialGauge = LiquidityGauge.load(
       currentPreferentialGaugeId,
     ) as LiquidityGauge;

--- a/src/voting.ts
+++ b/src/voting.ts
@@ -141,7 +141,6 @@ export function handleUserBalToChain(event: UserBalToChain): void {
   if (omniLock == null) {
     omniLock = new OmniVotingEscrowLock(id);
     omniLock.localUser = userAddress.toHexString();
-    omniLock.remoteUser = event.params.remoteUser;
     omniLock.votingEscrowID = '0xc128a9954e6c874ea3d62ce62b468ba073093f25';
     omniLock.dstChainId = event.params.dstChainId;
   }
@@ -149,6 +148,7 @@ export function handleUserBalToChain(event: UserBalToChain): void {
   omniLock.bias = scaleDownBPT(event.params.userPoint.bias);
   omniLock.slope = scaleDownBPT(event.params.userPoint.slope);
   omniLock.timestamp = event.params.userPoint.ts.toI32();
+  omniLock.remoteUser = event.params.remoteUser;
 
   omniLock.save();
 }


### PR DESCRIPTION
# Description

- #98 

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [x] [Aura's `OmniVotingEscrowLock` is set to `0xc181edc719480bd089b94647c2dc504e2700a2b0` on Gnosis](https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges-beta/graphql?query=%7B%0A%09omniVotingEscrowLocks(%0A++++where:+%7B%0A++++++localUser:+%220xaf52695e1bb01a16d33d7194c28c42b10e0dbec2%22%0A++++++dstChainId:+145+%23+LayerZero+Chain+ID+for+Gnosis+Chain%0A++++%7D%0A++)+%7B%0A%09++dstChainId%0A++++remoteUser%0A%09%7D%0A%7D%0A)

## Visual context

I verified Aura's boost is synced across all networks by pointing my local frontend to the staging subgraph.

<img width="1090" alt="image" src="https://github.com/balancer/gauges-subgraph/assets/43360747/9ae2a24a-bd00-47e8-aa2e-286c91bbf46a">

For comparison, this is what it looks like currently and has been reported by Aura.

<img width="1093" alt="image" src="https://github.com/balancer/gauges-subgraph/assets/43360747/2ac92841-dedf-4f00-a024-c3463772943b">

